### PR TITLE
v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# v0.5.2
+
+* upd: support any logging package with a `Printf` method via `Logger` interface rather than forcing `log.Logger` from standard log package
+* upd: remove explicit log level classifications from logging messages
+* upd: switch to errors package (for `errors.Wrap` et al.)
+* upd: clarify error messages
+* upd: refactor tests
+* fix: `SearchCheckBundles` to use `*SearchFilterType` as its second argument
+* fix: remove `NewAlert` - not applicable, alerts are not created via the API
+* add: ensure all `Delete*ByCID` methods have CID corrections so short CIDs can be passed
+
+# v0.5.1
+
+* upd: retryablehttp to start using versions that are now available instead of tracking master
+
+# v0.5.0
+
+* Initial - promoted from github.com/circonus-labs/circonus-gometrics/api to an independant package

--- a/account.go
+++ b/account.go
@@ -89,7 +89,7 @@ func (a *API) FetchAccount(cid CIDType) (*Account, error) {
 
 	account := new(Account)
 	if err := json.Unmarshal(result, account); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing account")
 	}
 
 	return account, nil
@@ -104,7 +104,7 @@ func (a *API) FetchAccounts() (*[]Account, error) {
 
 	var accounts []Account
 	if err := json.Unmarshal(result, &accounts); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing accounts")
 	}
 
 	return &accounts, nil
@@ -142,7 +142,7 @@ func (a *API) UpdateAccount(cfg *Account) (*Account, error) {
 
 	account := &Account{}
 	if err := json.Unmarshal(result, account); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing account")
 	}
 
 	return account, nil

--- a/account.go
+++ b/account.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/go-apiclient/config"
+	"github.com/pkg/errors"
 )
 
 // AccountLimit defines a usage limit imposed on account
@@ -74,16 +75,16 @@ func (a *API) FetchAccount(cid CIDType) (*Account, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid account CID [%s]", accountCID)
+		return nil, errors.Errorf("invalid account CID (%s)", accountCID)
 	}
 
 	result, err := a.Get(accountCID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching account")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] fetch account, received JSON: %s", string(result))
+		a.Log.Printf("fetch account, received JSON: %s", string(result))
 	}
 
 	account := new(Account)
@@ -98,7 +99,7 @@ func (a *API) FetchAccount(cid CIDType) (*Account, error) {
 func (a *API) FetchAccounts() (*[]Account, error) {
 	result, err := a.Get(config.AccountPrefix)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching accounts")
 	}
 
 	var accounts []Account
@@ -112,7 +113,7 @@ func (a *API) FetchAccounts() (*[]Account, error) {
 // UpdateAccount updates passed account.
 func (a *API) UpdateAccount(cfg *Account) (*Account, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Invalid account config [nil]")
+		return nil, errors.Errorf("invalid account config (nil)")
 	}
 
 	accountCID := cfg.CID
@@ -122,7 +123,7 @@ func (a *API) UpdateAccount(cfg *Account) (*Account, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid account CID [%s]", accountCID)
+		return nil, errors.Errorf("invalid account CID (%s)", accountCID)
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
@@ -131,12 +132,12 @@ func (a *API) UpdateAccount(cfg *Account) (*Account, error) {
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] account update, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("account update, sending JSON: %s", string(jsonCfg))
 	}
 
 	result, err := a.Put(accountCID, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "updating account")
 	}
 
 	account := &Account{}
@@ -172,7 +173,7 @@ func (a *API) SearchAccounts(filterCriteria *SearchFilterType) (*[]Account, erro
 
 	result, err := a.Get(reqURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] API call error %+v", err)
+		return nil, errors.Wrap(err, "searching accounts")
 	}
 
 	var accounts []Account

--- a/acknowledgement.go
+++ b/acknowledgement.go
@@ -69,7 +69,7 @@ func (a *API) FetchAcknowledgement(cid CIDType) (*Acknowledgement, error) {
 
 	acknowledgement := &Acknowledgement{}
 	if err := json.Unmarshal(result, acknowledgement); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing acknowledgement")
 	}
 
 	return acknowledgement, nil
@@ -84,7 +84,7 @@ func (a *API) FetchAcknowledgements() (*[]Acknowledgement, error) {
 
 	var acknowledgements []Acknowledgement
 	if err := json.Unmarshal(result, &acknowledgements); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing acknowledgements")
 	}
 
 	return &acknowledgements, nil
@@ -122,7 +122,7 @@ func (a *API) UpdateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, err
 
 	acknowledgement := &Acknowledgement{}
 	if err := json.Unmarshal(result, acknowledgement); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing acknowledgement")
 	}
 
 	return acknowledgement, nil
@@ -150,7 +150,7 @@ func (a *API) CreateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, err
 
 	acknowledgement := &Acknowledgement{}
 	if err := json.Unmarshal(result, acknowledgement); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing acknowledgement")
 	}
 
 	return acknowledgement, nil
@@ -190,7 +190,7 @@ func (a *API) SearchAcknowledgements(searchCriteria *SearchQueryType, filterCrit
 
 	var acknowledgements []Acknowledgement
 	if err := json.Unmarshal(result, &acknowledgements); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing acknowledgements")
 	}
 
 	return &acknowledgements, nil

--- a/acknowledgement.go
+++ b/acknowledgement.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/go-apiclient/config"
+	"github.com/pkg/errors"
 )
 
 // Acknowledgement defines a acknowledgement. See https://login.circonus.com/resources/api/calls/acknowledgement for more information.
@@ -39,7 +40,7 @@ func NewAcknowledgement() *Acknowledgement {
 // FetchAcknowledgement retrieves acknowledgement with passed cid.
 func (a *API) FetchAcknowledgement(cid CIDType) (*Acknowledgement, error) {
 	if cid == nil || *cid == "" {
-		return nil, fmt.Errorf("Invalid acknowledgement CID [none]")
+		return nil, errors.Errorf("invalid acknowledgement CID (none)")
 	}
 
 	var acknowledgementCID string
@@ -54,16 +55,16 @@ func (a *API) FetchAcknowledgement(cid CIDType) (*Acknowledgement, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid acknowledgement CID [%s]", acknowledgementCID)
+		return nil, errors.Errorf("invalid acknowledgement CID (%s)", acknowledgementCID)
 	}
 
 	result, err := a.Get(acknowledgementCID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching acknowledgement")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] fetch acknowledgement, received JSON: %s", string(result))
+		a.Log.Printf("fetch acknowledgement, received JSON: %s", string(result))
 	}
 
 	acknowledgement := &Acknowledgement{}
@@ -78,7 +79,7 @@ func (a *API) FetchAcknowledgement(cid CIDType) (*Acknowledgement, error) {
 func (a *API) FetchAcknowledgements() (*[]Acknowledgement, error) {
 	result, err := a.Get(config.AcknowledgementPrefix)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching acknowledgements")
 	}
 
 	var acknowledgements []Acknowledgement
@@ -92,7 +93,7 @@ func (a *API) FetchAcknowledgements() (*[]Acknowledgement, error) {
 // UpdateAcknowledgement updates passed acknowledgement.
 func (a *API) UpdateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Invalid acknowledgement config [nil]")
+		return nil, errors.Errorf("invalid acknowledgement config (nil)")
 	}
 
 	acknowledgementCID := cfg.CID
@@ -102,7 +103,7 @@ func (a *API) UpdateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, err
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid acknowledgement CID [%s]", acknowledgementCID)
+		return nil, errors.Errorf("invalid acknowledgement CID (%s)", acknowledgementCID)
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
@@ -111,12 +112,12 @@ func (a *API) UpdateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, err
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] acknowledgement update, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("acknowledgement update, sending JSON: %s", string(jsonCfg))
 	}
 
 	result, err := a.Put(acknowledgementCID, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "updating acknowledgement")
 	}
 
 	acknowledgement := &Acknowledgement{}
@@ -130,7 +131,7 @@ func (a *API) UpdateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, err
 // CreateAcknowledgement creates a new acknowledgement.
 func (a *API) CreateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Invalid acknowledgement config [nil]")
+		return nil, errors.Errorf("invalid acknowledgement config (nil)")
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
@@ -140,11 +141,11 @@ func (a *API) CreateAcknowledgement(cfg *Acknowledgement) (*Acknowledgement, err
 
 	result, err := a.Post(config.AcknowledgementPrefix, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating acknowledgement")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] acknowledgement create, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("acknowledgement create, sending JSON: %s", string(jsonCfg))
 	}
 
 	acknowledgement := &Acknowledgement{}
@@ -184,7 +185,7 @@ func (a *API) SearchAcknowledgements(searchCriteria *SearchQueryType, filterCrit
 
 	result, err := a.Get(reqURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] API call error %+v", err)
+		return nil, errors.Wrap(err, "searching acknowledgements")
 	}
 
 	var acknowledgements []Acknowledgement

--- a/acknowledgement_test.go
+++ b/acknowledgement_test.go
@@ -107,17 +107,8 @@ func testAcknowledgementServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(f))
 }
 
-func TestNewAcknowledgement(t *testing.T) {
-	bundle := NewAcknowledgement()
-	actualType := reflect.TypeOf(bundle)
-	if actualType.String() != "*apiclient.Acknowledgement" {
-		t.Fatalf("unexpected type (%s)", actualType.String())
-	}
-}
-
-func TestFetchAcknowledgement(t *testing.T) {
+func acknowledgementTestBootstrap(t *testing.T) (*API, *httptest.Server) {
 	server := testAcknowledgementServer()
-	defer server.Close()
 
 	ac := &Config{
 		TokenKey: "abc123",
@@ -126,8 +117,24 @@ func TestFetchAcknowledgement(t *testing.T) {
 	}
 	apih, err := NewAPI(ac)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
+		server.Close()
+		return nil, nil
 	}
+
+	return apih, server
+}
+
+func TestNewAcknowledgement(t *testing.T) {
+	ack := NewAcknowledgement()
+	if reflect.TypeOf(ack).String() != "*apiclient.Acknowledgement" {
+		t.Fatalf("unexpected type (%s)", reflect.TypeOf(ack).String())
+	}
+}
+
+func TestFetchAcknowledgement(t *testing.T) {
+	apih, server := acknowledgementTestBootstrap(t)
+	defer server.Close()
 
 	tests := []struct {
 		id           string
@@ -164,45 +171,22 @@ func TestFetchAcknowledgement(t *testing.T) {
 }
 
 func TestFetchAcknowledgements(t *testing.T) {
-	server := testAcknowledgementServer()
+	apih, server := acknowledgementTestBootstrap(t)
 	defer server.Close()
 
-	ac := &Config{
-		TokenKey: "abc123",
-		TokenApp: "test",
-		URL:      server.URL,
-	}
-	apih, err := NewAPI(ac)
+	acks, err := apih.FetchAcknowledgements()
 	if err != nil {
 		t.Fatalf("unexpected error (%s)", err)
 	}
 
-	acknowledgements, err := apih.FetchAcknowledgements()
-	if err != nil {
-		t.Fatalf("unexpected error (%s)", err)
-	}
-
-	actualType := reflect.TypeOf(acknowledgements)
-	if actualType.String() != "*[]apiclient.Acknowledgement" {
-		t.Fatalf("unexpected type (%s)", actualType.String())
+	if reflect.TypeOf(acks).String() != "*[]apiclient.Acknowledgement" {
+		t.Fatalf("unexpected type (%s)", reflect.TypeOf(acks).String())
 	}
 }
 
 func TestUpdateAcknowledgement(t *testing.T) {
-	server := testAcknowledgementServer()
+	apih, server := acknowledgementTestBootstrap(t)
 	defer server.Close()
-
-	var apih *API
-
-	ac := &Config{
-		TokenKey: "abc123",
-		TokenApp: "test",
-		URL:      server.URL,
-	}
-	apih, err := NewAPI(ac)
-	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
-	}
 
 	tests := []struct {
 		id          string
@@ -235,18 +219,8 @@ func TestUpdateAcknowledgement(t *testing.T) {
 }
 
 func TestCreateAcknowledgement(t *testing.T) {
-	server := testAcknowledgementServer()
+	apih, server := acknowledgementTestBootstrap(t)
 	defer server.Close()
-
-	ac := &Config{
-		TokenKey: "abc123",
-		TokenApp: "test",
-		URL:      server.URL,
-	}
-	apih, err := NewAPI(ac)
-	if err != nil {
-		t.Fatalf("unexpected error (%s)", err)
-	}
 
 	tests := []struct {
 		id           string
@@ -282,20 +256,8 @@ func TestCreateAcknowledgement(t *testing.T) {
 }
 
 func TestSearchAcknowledgement(t *testing.T) {
-	server := testAcknowledgementServer()
+	apih, server := acknowledgementTestBootstrap(t)
 	defer server.Close()
-
-	var apih *API
-
-	ac := &Config{
-		TokenKey: "abc123",
-		TokenApp: "test",
-		URL:      server.URL,
-	}
-	apih, err := NewAPI(ac)
-	if err != nil {
-		t.Fatalf("unexpected error (%s)", err)
-	}
 
 	expectedType := "*[]apiclient.Acknowledgement"
 	search := SearchQueryType(`(notes="something")`)

--- a/acknowledgement_test.go
+++ b/acknowledgement_test.go
@@ -6,15 +6,12 @@ package apiclient
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
-
-	"github.com/circonus-labs/go-apiclient/config"
 )
 
 var (
@@ -113,9 +110,8 @@ func testAcknowledgementServer() *httptest.Server {
 func TestNewAcknowledgement(t *testing.T) {
 	bundle := NewAcknowledgement()
 	actualType := reflect.TypeOf(bundle)
-	expectedType := "*apiclient.Acknowledgement"
-	if actualType.String() != expectedType {
-		t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
+	if actualType.String() != "*apiclient.Acknowledgement" {
+		t.Fatalf("unexpected type (%s)", actualType.String())
 	}
 }
 
@@ -133,61 +129,37 @@ func TestFetchAcknowledgement(t *testing.T) {
 		t.Errorf("Expected no error, got '%v'", err)
 	}
 
-	t.Log("invalid CID [nil]")
-	{
-		expectedError := errors.New("Invalid acknowledgement CID [none]")
-		_, err := apih.FetchAcknowledgement(nil)
-		if err == nil {
-			t.Fatalf("Expected error")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Expected %+v got '%+v'", expectedError, err)
-		}
+	tests := []struct {
+		id           string
+		cid          string
+		expectedType string
+		shouldFail   bool
+		expectedErr  string
+	}{
+		{"invalid (empty cid)", "", "", true, "invalid acknowledgement CID (none)"},
+		{"invalid (cid)", "/invalid", "", true, "invalid acknowledgement CID (/acknowledgement//invalid)"},
+		{"valid (short cid)", "1234", "*apiclient.Acknowledgement", false, ""},
+		{"valid (long cid)", "/acknowledgement/1234", "*apiclient.Acknowledgement", false, ""},
 	}
 
-	t.Log("invalid CID [\"\"]")
-	{
-		cid := ""
-		expectedError := errors.New("Invalid acknowledgement CID [none]")
-		_, err := apih.FetchAcknowledgement(CIDType(&cid))
-		if err == nil {
-			t.Fatalf("Expected error")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Expected %+v got '%+v'", expectedError, err)
-		}
-	}
-
-	t.Log("invalid CID [/invalid]")
-	{
-		cid := "/invalid"
-		expectedError := errors.New("Invalid acknowledgement CID [" + config.AcknowledgementPrefix + "/" + cid + "]")
-		_, err := apih.FetchAcknowledgement(CIDType(&cid))
-		if err == nil {
-			t.Fatalf("Expected error")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Expected %+v got '%+v'", expectedError, err)
-		}
-	}
-
-	t.Log("valid CID")
-	{
-		cid := "/acknowledgement/1234"
-		acknowledgement, err := apih.FetchAcknowledgement(CIDType(&cid))
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		actualType := reflect.TypeOf(acknowledgement)
-		expectedType := "*apiclient.Acknowledgement"
-		if actualType.String() != expectedType {
-			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
-		}
-
-		if acknowledgement.CID != testAcknowledgement.CID {
-			t.Fatalf("CIDs do not match: %+v != %+v\n", acknowledgement, testAcknowledgement)
-		}
+	for _, test := range tests {
+		test := test
+		t.Run(test.id, func(t *testing.T) {
+			ack, err := apih.FetchAcknowledgement(CIDType(&test.cid))
+			if test.shouldFail {
+				if err == nil {
+					t.Fatal("expected error")
+				} else if err.Error() != test.expectedErr {
+					t.Fatalf("unexpected error (%s)", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error (%s)", err)
+				} else if reflect.TypeOf(ack).String() != test.expectedType {
+					t.Fatalf("unexpected type (%s)", reflect.TypeOf(ack).String())
+				}
+			}
+		})
 	}
 }
 
@@ -202,20 +174,18 @@ func TestFetchAcknowledgements(t *testing.T) {
 	}
 	apih, err := NewAPI(ac)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
 	acknowledgements, err := apih.FetchAcknowledgements()
 	if err != nil {
-		t.Fatalf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
 	actualType := reflect.TypeOf(acknowledgements)
-	expectedType := "*[]apiclient.Acknowledgement"
-	if actualType.String() != expectedType {
-		t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
+	if actualType.String() != "*[]apiclient.Acknowledgement" {
+		t.Fatalf("unexpected type (%s)", actualType.String())
 	}
-
 }
 
 func TestUpdateAcknowledgement(t *testing.T) {
@@ -234,43 +204,33 @@ func TestUpdateAcknowledgement(t *testing.T) {
 		t.Errorf("Expected no error, got '%v'", err)
 	}
 
-	t.Log("invalid config [nil]")
-	{
-		expectedError := errors.New("Invalid acknowledgement config [nil]")
-		_, err := apih.UpdateAcknowledgement(nil)
-		if err == nil {
-			t.Fatal("Expected an error")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Expected %+v got '%+v'", expectedError, err)
-		}
+	tests := []struct {
+		id          string
+		cfg         *Acknowledgement
+		shouldFail  bool
+		expectedErr string
+	}{
+		{"invalid (nil)", nil, true, "invalid acknowledgement config (nil)"},
+		{"invalid (cid)", &Acknowledgement{CID: "/invalid"}, true, "invalid acknowledgement CID (/invalid)"},
+		{"valid", &testAcknowledgement, false, ""},
 	}
 
-	t.Log("invalid config [CID /invalid]")
-	{
-		expectedError := errors.New("Invalid acknowledgement CID [/invalid]")
-		x := &Acknowledgement{CID: "/invalid"}
-		_, err := apih.UpdateAcknowledgement(x)
-		if err == nil {
-			t.Fatal("Expected an error")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Expected %+v got '%+v'", expectedError, err)
-		}
-	}
-
-	t.Log("valid config")
-	{
-		acknowledgement, err := apih.UpdateAcknowledgement(&testAcknowledgement)
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		actualType := reflect.TypeOf(acknowledgement)
-		expectedType := "*apiclient.Acknowledgement"
-		if actualType.String() != expectedType {
-			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
-		}
+	for _, test := range tests {
+		test := test
+		t.Run(test.id, func(t *testing.T) {
+			_, err := apih.UpdateAcknowledgement(test.cfg)
+			if test.shouldFail {
+				if err == nil {
+					t.Fatal("expected error")
+				} else if err.Error() != test.expectedErr {
+					t.Fatalf("unexpected error (%s)", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error (%s)", err)
+				}
+			}
+		})
 	}
 }
 
@@ -285,33 +245,39 @@ func TestCreateAcknowledgement(t *testing.T) {
 	}
 	apih, err := NewAPI(ac)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
-	t.Log("invalid config [nil]")
-	{
-		expectedError := errors.New("Invalid acknowledgement config [nil]")
-		_, err := apih.CreateAcknowledgement(nil)
-		if err == nil {
-			t.Fatal("Expected an error")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Expected %+v got '%+v'", expectedError, err)
-		}
+	tests := []struct {
+		id           string
+		cfg          *Acknowledgement
+		expectedType string
+		shouldFail   bool
+		expectedErr  string
+	}{
+		{"invalid (nil)", nil, "", true, "invalid acknowledgement config (nil)"},
+		{"invalid (cid)", &Acknowledgement{CID: "/invalid"}, "", true, "invalid acknowledgement CID (/invalid)"},
+		{"valid", &testAcknowledgement, "*apiclient.Acknowledgement", false, ""},
 	}
 
-	t.Log("valid config")
-	{
-		acknowledgement, err := apih.CreateAcknowledgement(&testAcknowledgement)
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		actualType := reflect.TypeOf(acknowledgement)
-		expectedType := "*apiclient.Acknowledgement"
-		if actualType.String() != expectedType {
-			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
-		}
+	for _, test := range tests {
+		test := test
+		t.Run(test.id, func(t *testing.T) {
+			ack, err := apih.UpdateAcknowledgement(test.cfg)
+			if test.shouldFail {
+				if err == nil {
+					t.Fatal("expected error")
+				} else if err.Error() != test.expectedErr {
+					t.Fatalf("unexpected error (%s)", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error (%s)", err)
+				} else if reflect.TypeOf(ack).String() != test.expectedType {
+					t.Fatalf("unexpected type (%s)", reflect.TypeOf(ack).String())
+				}
+			}
+		})
 	}
 }
 
@@ -328,66 +294,44 @@ func TestSearchAcknowledgement(t *testing.T) {
 	}
 	apih, err := NewAPI(ac)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
-	t.Log("no search, no filter")
-	{
-		acknowledgements, err := apih.SearchAcknowledgements(nil, nil)
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
+	expectedType := "*[]apiclient.Acknowledgement"
+	search := SearchQueryType(`(notes="something")`)
+	filter := SearchFilterType(map[string][]string{"f__active": {"true"}})
 
-		actualType := reflect.TypeOf(acknowledgements)
-		expectedType := "*[]apiclient.Acknowledgement"
-		if actualType.String() != expectedType {
-			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
-		}
+	tests := []struct {
+		id           string
+		search       *SearchQueryType
+		filter       *SearchFilterType
+		expectedType string
+		shouldFail   bool
+		expectedErr  string
+	}{
+		{"no search, no filter", nil, nil, expectedType, false, ""},
+		{"search no filter", &search, nil, expectedType, false, ""},
+		{"filter no search", nil, &filter, expectedType, false, ""},
+		{"both filter and search", &search, &filter, expectedType, false, ""},
 	}
 
-	t.Log("search, no filter")
-	{
-		search := SearchQueryType(`(notes="something")`)
-		acknowledgements, err := apih.SearchAcknowledgements(&search, nil)
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		actualType := reflect.TypeOf(acknowledgements)
-		expectedType := "*[]apiclient.Acknowledgement"
-		if actualType.String() != expectedType {
-			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
-		}
-	}
-
-	t.Log("no search, filter")
-	{
-		filter := SearchFilterType(map[string][]string{"f__active": {"true"}})
-		acknowledgements, err := apih.SearchAcknowledgements(nil, &filter)
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		actualType := reflect.TypeOf(acknowledgements)
-		expectedType := "*[]apiclient.Acknowledgement"
-		if actualType.String() != expectedType {
-			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
-		}
-	}
-
-	t.Log("search, filter")
-	{
-		search := SearchQueryType(`(notes="something")`)
-		filter := SearchFilterType(map[string][]string{"f__active": {"true"}})
-		acknowledgements, err := apih.SearchAcknowledgements(&search, &filter)
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		actualType := reflect.TypeOf(acknowledgements)
-		expectedType := "*[]apiclient.Acknowledgement"
-		if actualType.String() != expectedType {
-			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
-		}
+	for _, test := range tests {
+		test := test
+		t.Run(test.id, func(t *testing.T) {
+			ack, err := apih.SearchAcknowledgements(test.search, test.filter)
+			if test.shouldFail {
+				if err == nil {
+					t.Fatal("expected error")
+				} else if err.Error() != test.expectedErr {
+					t.Fatalf("unexpected error (%s)", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error (%s)", err)
+				} else if reflect.TypeOf(ack).String() != test.expectedType {
+					t.Fatalf("unexpected type (%s)", reflect.TypeOf(ack).String())
+				}
+			}
+		})
 	}
 }

--- a/alert.go
+++ b/alert.go
@@ -39,11 +39,6 @@ type Alert struct {
 	Value              string   `json:"_value,omitempty"`           // string
 }
 
-// NewAlert returns a new alert (with defaults, if applicable)
-func NewAlert() *Alert {
-	return &Alert{}
-}
-
 // FetchAlert retrieves alert with passed cid.
 func (a *API) FetchAlert(cid CIDType) (*Alert, error) {
 	if cid == nil || *cid == "" {
@@ -76,7 +71,7 @@ func (a *API) FetchAlert(cid CIDType) (*Alert, error) {
 
 	alert := &Alert{}
 	if err := json.Unmarshal(result, alert); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing alert")
 	}
 
 	return alert, nil
@@ -91,7 +86,7 @@ func (a *API) FetchAlerts() (*[]Alert, error) {
 
 	var alerts []Alert
 	if err := json.Unmarshal(result, &alerts); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing alerts")
 	}
 
 	return &alerts, nil
@@ -131,7 +126,7 @@ func (a *API) SearchAlerts(searchCriteria *SearchQueryType, filterCriteria *Sear
 
 	var alerts []Alert
 	if err := json.Unmarshal(result, &alerts); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing alerts")
 	}
 
 	return &alerts, nil

--- a/alert.go
+++ b/alert.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/go-apiclient/config"
+	"github.com/pkg/errors"
 )
 
 // Alert defines a alert. See https://login.circonus.com/resources/api/calls/alert for more information.
@@ -46,7 +47,7 @@ func NewAlert() *Alert {
 // FetchAlert retrieves alert with passed cid.
 func (a *API) FetchAlert(cid CIDType) (*Alert, error) {
 	if cid == nil || *cid == "" {
-		return nil, fmt.Errorf("Invalid alert CID [none]")
+		return nil, errors.New("invalid alert CID (none)")
 	}
 
 	var alertCID string
@@ -61,16 +62,16 @@ func (a *API) FetchAlert(cid CIDType) (*Alert, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid alert CID [%s]", alertCID)
+		return nil, errors.Errorf("invalid alert CID (%s)", alertCID)
 	}
 
 	result, err := a.Get(alertCID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching alert")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] fetch alert, received JSON: %s", string(result))
+		a.Log.Printf("fetch alert, received JSON: %s", string(result))
 	}
 
 	alert := &Alert{}
@@ -85,7 +86,7 @@ func (a *API) FetchAlert(cid CIDType) (*Alert, error) {
 func (a *API) FetchAlerts() (*[]Alert, error) {
 	result, err := a.Get(config.AlertPrefix)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching alerts")
 	}
 
 	var alerts []Alert
@@ -125,7 +126,7 @@ func (a *API) SearchAlerts(searchCriteria *SearchQueryType, filterCriteria *Sear
 
 	result, err := a.Get(reqURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] API call error %+v", err)
+		return nil, errors.Wrap(err, "searching alerts")
 	}
 
 	var alerts []Alert

--- a/broker.go
+++ b/broker.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/go-apiclient/config"
+	"github.com/pkg/errors"
 )
 
 // BrokerDetail defines instance attributes
@@ -45,7 +46,7 @@ type Broker struct {
 // FetchBroker retrieves broker with passed cid.
 func (a *API) FetchBroker(cid CIDType) (*Broker, error) {
 	if cid == nil || *cid == "" {
-		return nil, fmt.Errorf("Invalid broker CID [none]")
+		return nil, errors.Errorf("invalid broker CID (none)")
 	}
 
 	var brokerCID string
@@ -60,21 +61,21 @@ func (a *API) FetchBroker(cid CIDType) (*Broker, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid broker CID [%s]", brokerCID)
+		return nil, errors.Errorf("invalid broker CID (%s)", brokerCID)
 	}
 
 	result, err := a.Get(brokerCID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching broker")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] fetch broker, received JSON: %s", string(result))
+		a.Log.Printf("fetch broker, received JSON: %s", string(result))
 	}
 
 	response := new(Broker)
 	if err := json.Unmarshal(result, &response); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing broker")
 	}
 
 	return response, nil
@@ -85,12 +86,12 @@ func (a *API) FetchBroker(cid CIDType) (*Broker, error) {
 func (a *API) FetchBrokers() (*[]Broker, error) {
 	result, err := a.Get(config.BrokerPrefix)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching brokers")
 	}
 
 	var response []Broker
 	if err := json.Unmarshal(result, &response); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing brokers")
 	}
 
 	return &response, nil
@@ -125,12 +126,12 @@ func (a *API) SearchBrokers(searchCriteria *SearchQueryType, filterCriteria *Sea
 
 	result, err := a.Get(reqURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] API call error %+v", err)
+		return nil, errors.Wrap(err, "searching brokers")
 	}
 
 	var brokers []Broker
 	if err := json.Unmarshal(result, &brokers); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing brokers")
 	}
 
 	return &brokers, nil

--- a/check_bundle_metrics.go
+++ b/check_bundle_metrics.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/go-apiclient/config"
+	"github.com/pkg/errors"
 )
 
 // CheckBundleMetrics defines metrics for a specific check bundle. See https://login.circonus.com/resources/api/calls/check_bundle_metrics for more information.
@@ -27,7 +28,7 @@ type CheckBundleMetrics struct {
 // FetchCheckBundleMetrics retrieves metrics for the check bundle with passed cid.
 func (a *API) FetchCheckBundleMetrics(cid CIDType) (*CheckBundleMetrics, error) {
 	if cid == nil || *cid == "" {
-		return nil, fmt.Errorf("Invalid check bundle metrics CID [none]")
+		return nil, errors.New("invalid check bundle metrics CID (none)")
 	}
 
 	var metricsCID string
@@ -42,21 +43,21 @@ func (a *API) FetchCheckBundleMetrics(cid CIDType) (*CheckBundleMetrics, error) 
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid check bundle metrics CID [%s]", metricsCID)
+		return nil, errors.Errorf("invalid check bundle metrics CID (%s)", metricsCID)
 	}
 
 	result, err := a.Get(metricsCID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching check bundle metrics")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] fetch check bundle metrics, received JSON: %s", string(result))
+		a.Log.Printf("fetch check bundle metrics, received JSON: %s", string(result))
 	}
 
 	metrics := &CheckBundleMetrics{}
 	if err := json.Unmarshal(result, metrics); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing check bundle metrics")
 	}
 
 	return metrics, nil
@@ -65,7 +66,7 @@ func (a *API) FetchCheckBundleMetrics(cid CIDType) (*CheckBundleMetrics, error) 
 // UpdateCheckBundleMetrics updates passed metrics.
 func (a *API) UpdateCheckBundleMetrics(cfg *CheckBundleMetrics) (*CheckBundleMetrics, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Invalid check bundle metrics config [nil]")
+		return nil, errors.New("invalid check bundle metrics config (nil)")
 	}
 
 	metricsCID := cfg.CID
@@ -75,7 +76,7 @@ func (a *API) UpdateCheckBundleMetrics(cfg *CheckBundleMetrics) (*CheckBundleMet
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid check bundle metrics CID [%s]", metricsCID)
+		return nil, errors.Errorf("invalid check bundle metrics CID (%s)", metricsCID)
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
@@ -84,17 +85,17 @@ func (a *API) UpdateCheckBundleMetrics(cfg *CheckBundleMetrics) (*CheckBundleMet
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] update check bundle metrics, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("update check bundle metrics, sending JSON: %s", string(jsonCfg))
 	}
 
 	result, err := a.Put(metricsCID, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "updating check bundle metrics")
 	}
 
 	metrics := &CheckBundleMetrics{}
 	if err := json.Unmarshal(result, metrics); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing check bundle metrics")
 	}
 
 	return metrics, nil

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/circonus-labs/go-apiclient
 
-require github.com/hashicorp/go-retryablehttp v0.5.0
+require (
+	github.com/hashicorp/go-retryablehttp v0.5.0
+	github.com/pkg/errors v0.8.0
+)

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6K
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-retryablehttp v0.5.0 h1:aVN0FYnPwAgZI/hVzqwfMiM86ttcHTlQKbBVeVmXPIs=
 github.com/hashicorp/go-retryablehttp v0.5.0/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/provision_broker.go
+++ b/provision_broker.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/go-apiclient/config"
+	"github.com/pkg/errors"
 )
 
 // BrokerStratcon defines stratcons for broker
@@ -51,7 +52,7 @@ func NewProvisionBroker() *ProvisionBroker {
 // FetchProvisionBroker retrieves provision broker [request] with passed cid.
 func (a *API) FetchProvisionBroker(cid CIDType) (*ProvisionBroker, error) {
 	if cid == nil || *cid == "" {
-		return nil, fmt.Errorf("Invalid provision broker request CID [none]")
+		return nil, errors.New("invalid provision broker CID (none)")
 	}
 
 	var brokerCID string
@@ -66,21 +67,21 @@ func (a *API) FetchProvisionBroker(cid CIDType) (*ProvisionBroker, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid provision broker request CID [%s]", brokerCID)
+		return nil, errors.Errorf("invalid provision broker CID (%s)", brokerCID)
 	}
 
 	result, err := a.Get(brokerCID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching provision broker")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] fetch broker provision request, received JSON: %s", string(result))
+		a.Log.Printf("fetch broker provision request, received JSON: %s", string(result))
 	}
 
 	broker := &ProvisionBroker{}
 	if err := json.Unmarshal(result, broker); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing provision broker")
 	}
 
 	return broker, nil
@@ -88,12 +89,12 @@ func (a *API) FetchProvisionBroker(cid CIDType) (*ProvisionBroker, error) {
 
 // UpdateProvisionBroker updates a broker definition [request].
 func (a *API) UpdateProvisionBroker(cid CIDType, cfg *ProvisionBroker) (*ProvisionBroker, error) {
-	if cfg == nil {
-		return nil, fmt.Errorf("Invalid provision broker request config [nil]")
+	if cid == nil || *cid == "" {
+		return nil, errors.New("invalid provision broker CID (none)")
 	}
 
-	if cid == nil || *cid == "" {
-		return nil, fmt.Errorf("Invalid provision broker request CID [none]")
+	if cfg == nil {
+		return nil, errors.New("invalid provision broker config (nil)")
 	}
 
 	brokerCID := *cid
@@ -103,7 +104,7 @@ func (a *API) UpdateProvisionBroker(cid CIDType, cfg *ProvisionBroker) (*Provisi
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid provision broker request CID [%s]", brokerCID)
+		return nil, errors.Errorf("invalid provision broker CID (%s)", brokerCID)
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
@@ -112,17 +113,17 @@ func (a *API) UpdateProvisionBroker(cid CIDType, cfg *ProvisionBroker) (*Provisi
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] update broker provision request, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("update broker provision request, sending JSON: %s", string(jsonCfg))
 	}
 
 	result, err := a.Put(brokerCID, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "updating provision broker")
 	}
 
 	broker := &ProvisionBroker{}
 	if err := json.Unmarshal(result, broker); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing provision broker")
 	}
 
 	return broker, nil
@@ -131,7 +132,7 @@ func (a *API) UpdateProvisionBroker(cid CIDType, cfg *ProvisionBroker) (*Provisi
 // CreateProvisionBroker creates a new provison broker [request].
 func (a *API) CreateProvisionBroker(cfg *ProvisionBroker) (*ProvisionBroker, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Invalid provision broker request config [nil]")
+		return nil, errors.New("invalid provision broker config (nil)")
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
@@ -140,17 +141,17 @@ func (a *API) CreateProvisionBroker(cfg *ProvisionBroker) (*ProvisionBroker, err
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] create broker provision request, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("create broker provision request, sending JSON: %s", string(jsonCfg))
 	}
 
 	result, err := a.Post(config.ProvisionBrokerPrefix, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating provision broker")
 	}
 
 	broker := &ProvisionBroker{}
 	if err := json.Unmarshal(result, broker); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing provision broker")
 	}
 
 	return broker, nil

--- a/rule_set_group.go
+++ b/rule_set_group.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/go-apiclient/config"
+	"github.com/pkg/errors"
 )
 
 // RuleSetGroupFormula defines a formula for raising alerts
@@ -48,7 +49,7 @@ func NewRuleSetGroup() *RuleSetGroup {
 // FetchRuleSetGroup retrieves rule set group with passed cid.
 func (a *API) FetchRuleSetGroup(cid CIDType) (*RuleSetGroup, error) {
 	if cid == nil || *cid == "" {
-		return nil, fmt.Errorf("Invalid rule set group CID [none]")
+		return nil, errors.New("invalid rule set group CID (none)")
 	}
 
 	var groupCID string
@@ -63,21 +64,21 @@ func (a *API) FetchRuleSetGroup(cid CIDType) (*RuleSetGroup, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid rule set group CID [%s]", groupCID)
+		return nil, errors.Errorf("invalid rule set group CID (%s)", groupCID)
 	}
 
 	result, err := a.Get(groupCID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching rule set group")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] fetch rule set group, received JSON: %s", string(result))
+		a.Log.Printf("fetch rule set group, received JSON: %s", string(result))
 	}
 
 	rulesetGroup := &RuleSetGroup{}
 	if err := json.Unmarshal(result, rulesetGroup); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing rule set group")
 	}
 
 	return rulesetGroup, nil
@@ -87,12 +88,12 @@ func (a *API) FetchRuleSetGroup(cid CIDType) (*RuleSetGroup, error) {
 func (a *API) FetchRuleSetGroups() (*[]RuleSetGroup, error) {
 	result, err := a.Get(config.RuleSetGroupPrefix)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching rule set groups")
 	}
 
 	var rulesetGroups []RuleSetGroup
 	if err := json.Unmarshal(result, &rulesetGroups); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing rule set groups")
 	}
 
 	return &rulesetGroups, nil
@@ -101,7 +102,7 @@ func (a *API) FetchRuleSetGroups() (*[]RuleSetGroup, error) {
 // UpdateRuleSetGroup updates passed rule set group.
 func (a *API) UpdateRuleSetGroup(cfg *RuleSetGroup) (*RuleSetGroup, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Invalid rule set group config [nil]")
+		return nil, errors.New("invalid rule set group config (nil)")
 	}
 
 	groupCID := cfg.CID
@@ -111,26 +112,26 @@ func (a *API) UpdateRuleSetGroup(cfg *RuleSetGroup) (*RuleSetGroup, error) {
 		return nil, err
 	}
 	if !matched {
-		return nil, fmt.Errorf("Invalid rule set group CID [%s]", groupCID)
+		return nil, errors.Errorf("invalid rule set group CID (%s)", groupCID)
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "updating rule set group")
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] update rule set group, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("update rule set group, sending JSON: %s", string(jsonCfg))
 	}
 
 	result, err := a.Put(groupCID, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "updating rule set group")
 	}
 
 	groups := &RuleSetGroup{}
 	if err := json.Unmarshal(result, groups); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing rule set group")
 	}
 
 	return groups, nil
@@ -139,7 +140,7 @@ func (a *API) UpdateRuleSetGroup(cfg *RuleSetGroup) (*RuleSetGroup, error) {
 // CreateRuleSetGroup creates a new rule set group.
 func (a *API) CreateRuleSetGroup(cfg *RuleSetGroup) (*RuleSetGroup, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Invalid rule set group config [nil]")
+		return nil, errors.New("invalid rule set group config (nil)")
 	}
 
 	jsonCfg, err := json.Marshal(cfg)
@@ -148,17 +149,17 @@ func (a *API) CreateRuleSetGroup(cfg *RuleSetGroup) (*RuleSetGroup, error) {
 	}
 
 	if a.Debug {
-		a.Log.Printf("[DEBUG] create rule set group, sending JSON: %s", string(jsonCfg))
+		a.Log.Printf("create rule set group, sending JSON: %s", string(jsonCfg))
 	}
 
 	result, err := a.Post(config.RuleSetGroupPrefix, jsonCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating rule set group")
 	}
 
 	group := &RuleSetGroup{}
 	if err := json.Unmarshal(result, group); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing rule set group")
 	}
 
 	return group, nil
@@ -167,7 +168,7 @@ func (a *API) CreateRuleSetGroup(cfg *RuleSetGroup) (*RuleSetGroup, error) {
 // DeleteRuleSetGroup deletes passed rule set group.
 func (a *API) DeleteRuleSetGroup(cfg *RuleSetGroup) (bool, error) {
 	if cfg == nil {
-		return false, fmt.Errorf("Invalid rule set group config [nil]")
+		return false, errors.New("invalid rule set group config (nil)")
 	}
 	return a.DeleteRuleSetGroupByCID(CIDType(&cfg.CID))
 }
@@ -175,22 +176,27 @@ func (a *API) DeleteRuleSetGroup(cfg *RuleSetGroup) (bool, error) {
 // DeleteRuleSetGroupByCID deletes rule set group with passed cid.
 func (a *API) DeleteRuleSetGroupByCID(cid CIDType) (bool, error) {
 	if cid == nil || *cid == "" {
-		return false, fmt.Errorf("Invalid rule set group CID [none]")
+		return false, errors.New("invalid rule set group CID (none)")
 	}
 
-	groupCID := *cid
+	var groupCID string
+	if !strings.HasPrefix(*cid, config.RuleSetGroupPrefix) {
+		groupCID = fmt.Sprintf("%s/%s", config.RuleSetGroupPrefix, *cid)
+	} else {
+		groupCID = *cid
+	}
 
 	matched, err := regexp.MatchString(config.RuleSetGroupCIDRegex, groupCID)
 	if err != nil {
 		return false, err
 	}
 	if !matched {
-		return false, fmt.Errorf("Invalid rule set group CID [%s]", groupCID)
+		return false, errors.Errorf("invalid rule set group CID (%s)", groupCID)
 	}
 
 	_, err = a.Delete(groupCID)
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, "deleting rule set group")
 	}
 
 	return true, nil
@@ -225,12 +231,12 @@ func (a *API) SearchRuleSetGroups(searchCriteria *SearchQueryType, filterCriteri
 
 	result, err := a.Get(reqURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] API call error %+v", err)
+		return nil, errors.Wrap(err, "searching rule set groups")
 	}
 
 	var groups []RuleSetGroup
 	if err := json.Unmarshal(result, &groups); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parsing rule set groups")
 	}
 
 	return &groups, nil


### PR DESCRIPTION
* upd: support any logging package with a `Printf` method via `Logger` interface rather than forcing `log.Logger` from standard log package
* upd: remove explicit log level classifications from logging messages
* upd: switch to errors package (for `errors.Wrap` et al.)
* upd: clarify error messages
* upd: refactor tests
* fix: `SearchCheckBundles` to use `*SearchFilterType` as its second argument
* fix: remove `NewAlert` - not applicable, alerts are not created via the API
* add: ensure all `Delete*ByCID` methods have CID corrections so short CIDs can be passed
