### PR TITLE
v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.5.3
+
+* upd: use std log for retryablehttp until dependency releases Logger interface
+
 # v0.5.2
 
 * upd: support any logging package with a `Printf` method via `Logger` interface rather than forcing `log.Logger` from standard log package

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func New(ac *Config) (*API, error) {
 	a.Debug = ac.Debug
 	a.Log = ac.Log
 	if a.Debug && a.Log == nil {
-		a.Log = log.New(os.Stderr, "", log.LstdFlags)
+		a.Log = log.New(os.Stdout, "", log.LstdFlags)
 	}
 	if a.Log == nil {
 		a.Log = log.New(ioutil.Discard, "", log.LstdFlags)
@@ -380,7 +380,9 @@ func (a *API) apiCall(reqMethod string, reqPath string, data []byte) ([]byte, er
 
 	// retryablehttp only groks log or no log
 	if a.Debug {
-		client.Logger = a.Log.(*log.Logger)
+		// uncomment below when Logger interface hits retryablehttp release
+		// client.Logger = a.Log
+		client.Logger = log.New(os.Stdout, "", log.LstdFlags)
 	} else {
 		client.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
 	}


### PR DESCRIPTION
* upd: use std log in retryablehttp until dependency releases Logger interface