### PR TITLE
v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.5.4
+
+* add: `search` (`*string`) attribute to graph datapoint
+* upd: `cluster_ip` (`*string`) can be string OR null
+* add: `cluster_ip` attribute to broker details
+
 # v0.5.3
 
 * upd: use std log for retryablehttp until dependency releases Logger interface

--- a/broker.go
+++ b/broker.go
@@ -20,7 +20,7 @@ import (
 
 // BrokerDetail defines instance attributes
 type BrokerDetail struct {
-	ClusterIP    string   `json:"cluster_ip"`               // string
+	ClusterIP    *string  `json:"cluster_ip"`               // string or null
 	CN           string   `json:"cn"`                       // string
 	ExternalHost *string  `json:"external_host"`            // string or null
 	ExternalPort uint16   `json:"external_port"`            // uint16

--- a/broker.go
+++ b/broker.go
@@ -20,6 +20,7 @@ import (
 
 // BrokerDetail defines instance attributes
 type BrokerDetail struct {
+	ClusterIP    string   `json:"cluster_ip"`               // string
 	CN           string   `json:"cn"`                       // string
 	ExternalHost *string  `json:"external_host"`            // string or null
 	ExternalPort uint16   `json:"external_port"`            // uint16

--- a/graph.go
+++ b/graph.go
@@ -62,6 +62,7 @@ type GraphDatapoint struct {
 	MetricName    string      `json:"metric_name,omitempty"`  // string
 	MetricType    string      `json:"metric_type,omitempty"`  // string
 	Name          string      `json:"name"`                   // string
+	Search        *string     `json:"search"`                 // string or null
 	Stack         *uint       `json:"stack"`                  // uint or null
 }
 


### PR DESCRIPTION
* add: `search` (`*string`) attribute to graph datapoint
* upd: `cluster_ip` (`*string`) can be string OR null
* add: `cluster_ip` attribute to broker details