### PR TITLE
v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.6.4
+
+* fix: graph.datapoint.alpha - doc:floating point number, api:string
+
 # v0.6.3
 
 * upd: remove tests for invalid cids

--- a/graph.go
+++ b/graph.go
@@ -50,7 +50,7 @@ type GraphComposite struct {
 
 // GraphDatapoint defines a datapoint
 type GraphDatapoint struct {
-	Alpha         *float64    `json:"alpha,omitempty"`       // float64
+	Alpha         *string     `json:"alpha,omitempty"`       // BUG: doc: floating point number, api: string
 	Axis          string      `json:"axis,omitempty"`        // string
 	CAQL          *string     `json:"caql,omitempty"`        // string or null
 	CheckID       uint        `json:"check_id,omitempty"`    // uint


### PR DESCRIPTION
* fix: graph.datapoint.alpha - doc:floating point number, api:string