### PR TITLE
v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.7.0
+
+* fix: forecast gauge `flip` required, remove omitempty
+* upd: range hi/low switched from `int` to `*int` so that 0 can be used, but common setting attribute still omitted for widgets which do not support the range settings
+
 # v0.6.9
 
 * fix: contact_group.`alert_formats`, individual fields should be omitted if not set (was `string|null`, now `string|omit`)

--- a/dashboard.go
+++ b/dashboard.go
@@ -94,7 +94,7 @@ type ChartWidgtDefinition struct {
 // ForecastGaugeWidgetThresholds defines forecast widget thresholds
 type ForecastGaugeWidgetThresholds struct {
 	Colors []string `json:"colors,omitempty"` // forecasts, gauges
-	Flip   bool     `json:"flip,omitempty"`   // gauges
+	Flip   bool     `json:"flip"`             // gauges 2019-11-01, flip is required
 	Values []string `json:"values,omitempty"` // forecasts, gauges
 }
 
@@ -160,8 +160,8 @@ type DashboardWidgetSettings struct {
 	OffHours            []uint                           `json:"off_hours,omitempty"`             // alerts
 	OverlaySetID        string                           `json:"overlay_set_id,omitempty"`        // graphs
 	Period              uint                             `json:"period,omitempty"`                // gauges, text, graphs
-	RangeHigh           int                              `json:"range_high,omitempty"`            // gauges
-	RangeLow            int                              `json:"range_low,omitempty"`             // gauges
+	RangeHigh           *int                             `json:"range_high,omitempty"`            // gauges 2019-11-01 switch to pointer for 0 ranges
+	RangeLow            *int                             `json:"range_low,omitempty"`             // gauges 2019-11-01 switch to pointer for 0 ranges
 	Realtime            bool                             `json:"realtime,omitempty"`              // graphs
 	ResourceLimit       string                           `json:"resource_limit,omitempty"`        // forecasts
 	ResourceUsage       string                           `json:"resource_usage,omitempty"`        // forecasts

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -544,7 +544,7 @@ func TestFetchDashboard(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.id, func(t *testing.T) {
-			alert, err := apih.FetchDashboard(CIDType(&test.cid))
+			dash, err := apih.FetchDashboard(CIDType(&test.cid))
 			if test.shouldFail {
 				if err == nil {
 					t.Fatal("expected error")
@@ -554,9 +554,15 @@ func TestFetchDashboard(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Fatalf("unexpected error (%s)", err)
-				} else if reflect.TypeOf(alert).String() != test.expectedType {
-					t.Fatalf("unexpected type (%s)", reflect.TypeOf(alert).String())
-				}
+				} else if reflect.TypeOf(dash).String() != test.expectedType {
+					t.Fatalf("unexpected type (%s)", reflect.TypeOf(dash).String())
+				} /* else {
+					data, err := json.MarshalIndent(dash, "", "  ")
+					if err != nil {
+						t.Fatalf("unexpected error marshing (%s)", err)
+					}
+					fmt.Printf("%s\n", string(data))
+				}*/
 			}
 		})
 	}


### PR DESCRIPTION
* fix: forecast gauge `flip` required, remove omitempty
* upd: range hi/low switched from `int` to `*int` so that 0 can be used, but common setting attribute still omitted for widgets which do not support the range settings