### PR TITLE
break on 404 error codes when using exp. backoff

### DIFF
--- a/main.go
+++ b/main.go
@@ -252,6 +252,9 @@ func (a *API) apiRequest(reqMethod string, reqPath string, data []byte) ([]byte,
 			if strings.Contains(err.Error(), "code 403") {
 				break
 			}
+			if strings.Contains(err.Error(), "code 404") {
+				break
+			}
 		}
 
 		if !success {


### PR DESCRIPTION
This is sort of a hack solution.. probably have a policy on a range of 400 level errors but it fixes the issue for now.