### PR TITLE
v0.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.7.11
+
+* add: new `user_json` field support to rule_set
+* upd: make timeout/retry tests optional (env var)
+
 # v0.7.10
 
 * upd: add 429 rate limit tests

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 )
@@ -428,7 +429,9 @@ func TestApiDelete(t *testing.T) {
 }
 
 func TestApiRequest(t *testing.T) {
-	// t.Skip()
+	if os.Getenv("DO_RETRY_TESTS") == "" {
+		t.Skip("Skipping retry tests - DO_RETRY_TESTS environment var not set")
+	}
 
 	server := retryCallServer()
 	defer server.Close()

--- a/rule_set.go
+++ b/rule_set.go
@@ -44,6 +44,7 @@ type RuleSet struct {
 	MetricType    string             `json:"metric_type"`              // string
 	Name          string             `json:"name,omitempty"`           // string
 	Notes         *string            `json:"notes"`                    // string or null
+	UserJSON      json.RawMessage    `json:"user_json,omitempty"`      // // abitrary json the ruleset creator supplies.. this is opaque and only has to be parseable JSON <= 4096 chars
 	Parent        *string            `json:"parent,omitempty"`         // string or null
 	Rules         []RuleSetRule      `json:"rules"`                    // [] len >= 1
 	Tags          []string           `json:"tags"`                     // [] len >= 0

--- a/rule_set_test.go
+++ b/rule_set_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 var (
+	u2          = []byte(`{"foo":"bar"}`)
 	testRuleSet = RuleSet{
 		CID:      "/rule_set/1234_tt_firstbyte",
 		CheckCID: "/check/1234",
@@ -29,6 +30,7 @@ var (
 		MetricName: "tt_firstbyte",
 		MetricType: "numeric",
 		Notes:      &[]string{"Determine if the HTTP request is taking too long to start (or is down.)  Don't fire if ping is already alerting"}[0],
+		UserJSON:   json.RawMessage(`{"foo":"bar","b2": {"bar":1},"b3":[1,2,3]}`),
 		Parent:     &[]string{"1233_ping"}[0],
 		Rules: []RuleSetRule{
 			{
@@ -65,6 +67,7 @@ var (
 		MetricName: "tt_firstbyte",
 		MetricType: "numeric",
 		Notes:      &[]string{"Determine if the HTTP request is taking too long to start (or is down.)  Don't fire if ping is already alerting"}[0],
+		UserJSON:   json.RawMessage(u2),
 		Parent:     &[]string{"1233_ping"}[0],
 		Rules: []RuleSetRule{
 			{


### PR DESCRIPTION
* add: new `user_json` field support to rule_set
* upd: make timeout/retry tests optional (env var)
