### PR TITLE
CIRC-8503: Update Account and Dashboard types to reflect defaulting changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,9 +11,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/setup-go@v3
         with:
-          version: v1.38
+          stable: true
+          go-version: 1.17.x
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.2.0
+        with:
           args: --timeout=5m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.7.16
+
+* upd: Adds the `default_dashboard_uuid` and `default_dashboard_type` optional
+fields to the Account type. And, removes the `account_default` field from the
+Dashboard type. This is to reflect the changes made to the dashboard defaulting
+process in the Circonus API.
+
 # v0.7.15
 
 * fix: do not allow blank tags through on check bundle creation

--- a/account.go
+++ b/account.go
@@ -40,22 +40,24 @@ type AccountUser struct {
 
 // Account defines an account. See https://login.circonus.com/resources/api/calls/account for more information.
 type Account struct {
-	CID           string          `json:"_cid,omitempty"`            // string
-	Country       string          `json:"country_code,omitempty"`    // string
-	Name          string          `json:"name,omitempty"`            // string
-	OwnerCID      string          `json:"_owner,omitempty"`          // string
-	Timezone      string          `json:"timezone,omitempty"`        // string
-	UIBaseURL     string          `json:"_ui_base_url,omitempty"`    // string
-	Address1      *string         `json:"address1,omitempty"`        // string or null
-	Address2      *string         `json:"address2,omitempty"`        // string or null
-	CCEmail       *string         `json:"cc_email,omitempty"`        // string or null
-	City          *string         `json:"city,omitempty"`            // string or null
-	Description   *string         `json:"description,omitempty"`     // string or null
-	StateProv     *string         `json:"state_prov,omitempty"`      // string or null
-	ContactGroups []string        `json:"_contact_groups,omitempty"` // [] len >= 0
-	Invites       []AccountInvite `json:"invites,omitempty"`         // [] len >= 0
-	Usage         []AccountLimit  `json:"_usage,omitempty"`          // [] len >= 0
-	Users         []AccountUser   `json:"users,omitempty"`           // [] len >= 0
+	CID                  string          `json:"_cid,omitempty"`                   // string
+	Country              string          `json:"country_code,omitempty"`           // string
+	Name                 string          `json:"name,omitempty"`                   // string
+	OwnerCID             string          `json:"_owner,omitempty"`                 // string
+	Timezone             string          `json:"timezone,omitempty"`               // string
+	UIBaseURL            string          `json:"_ui_base_url,omitempty"`           // string
+	Address1             *string         `json:"address1,omitempty"`               // string or null
+	Address2             *string         `json:"address2,omitempty"`               // string or null
+	CCEmail              *string         `json:"cc_email,omitempty"`               // string or null
+	City                 *string         `json:"city,omitempty"`                   // string or null
+	DefaultDashboardUUID *string         `json:"default_dashboard_uuid,omitempty"` // string or null
+	DefaultDashboardType *string         `json:"default_dashboard_type,omitempty"` // string or null
+	Description          *string         `json:"description,omitempty"`            // string or null
+	StateProv            *string         `json:"state_prov,omitempty"`             // string or null
+	ContactGroups        []string        `json:"_contact_groups,omitempty"`        // [] len >= 0
+	Invites              []AccountInvite `json:"invites,omitempty"`                // [] len >= 0
+	Usage                []AccountLimit  `json:"_usage,omitempty"`                 // [] len >= 0
+	Users                []AccountUser   `json:"users,omitempty"`                  // [] len >= 0
 }
 
 // FetchAccount retrieves account with passed cid. Pass nil for '/account/current'.

--- a/account_test.go
+++ b/account_test.go
@@ -54,6 +54,8 @@ var (
 				UserCID: "/user/42",
 			},
 		},
+		DefaultDashboardUUID: &[]string{"11223344-5566-7788-9900-aabbccddeeff"}[0],
+		DefaultDashboardType: &[]string{"custom"}[0],
 	}
 )
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -212,18 +212,17 @@ type DashboardWidget struct {
 
 // Dashboard defines a dashboard. See https://login.circonus.com/resources/api/calls/dashboard for more information.
 type Dashboard struct {
-	CID            string              `json:"_cid,omitempty"`
-	CreatedBy      string              `json:"_created_by,omitempty"`
-	Title          string              `json:"title"`
-	UUID           string              `json:"_dashboard_uuid,omitempty"`
-	Widgets        []DashboardWidget   `json:"widgets"`
-	Options        DashboardOptions    `json:"options"`
-	GridLayout     DashboardGridLayout `json:"grid_layout"`
-	Created        uint                `json:"_created,omitempty"`
-	LastModified   uint                `json:"_last_modified,omitempty"`
-	AccountDefault bool                `json:"account_default"`
-	Active         bool                `json:"_active,omitempty"`
-	Shared         bool                `json:"shared"`
+	CID          string              `json:"_cid,omitempty"`
+	CreatedBy    string              `json:"_created_by,omitempty"`
+	Title        string              `json:"title"`
+	UUID         string              `json:"_dashboard_uuid,omitempty"`
+	Widgets      []DashboardWidget   `json:"widgets"`
+	Options      DashboardOptions    `json:"options"`
+	GridLayout   DashboardGridLayout `json:"grid_layout"`
+	Created      uint                `json:"_created,omitempty"`
+	LastModified uint                `json:"_last_modified,omitempty"`
+	Active       bool                `json:"_active,omitempty"`
+	Shared       bool                `json:"shared"`
 }
 
 // NewDashboard returns a new Dashboard (with defaults, if applicable)

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -26,7 +26,6 @@ var jsondash = `{
   "_created_by": "/user/1234",
   "_dashboard_uuid": "01234567-89ab-cdef-0123-456789abcdef",
   "_last_modified": 1483450351,
-  "account_default": false,
   "grid_layout": {
     "height": 4,
     "width": 4

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.13
 // +build go1.13
 
 package apiclient


### PR DESCRIPTION
* upd: Adds the `default_dashboard_uuid` and `default_dashboard_type` optional fields to the Account type. And, removes the `account_default` field from the Dashboard type. This is to reflect the changes made to the dashboard defaulting process in the Circonus API.
* Also updates the golangci-lint GitHub action for this repo to use the latest version so it stops failing with errors.