### PR TITLE
CIRC-8734: Allow retries to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.7.17
 
-* upd: Allows MaxRetries configuration setting to be set to 0. This allows
-retry functionality to be disabled if desired.
+* upd: Implements a new DisableRetries configuration setting to allow the
+retry functionality to be disabled when needed.
 
 # v0.7.16
 

--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ type Config struct {
 	MinRetryDelay  string
 	MaxRetryDelay  string
 	MaxRetries     uint
+	DisableRetries bool
 	Debug          bool
 }
 
@@ -187,9 +188,14 @@ func New(ac *Config) (*API, error) {
 	}
 
 	a.maxRetries = maxRetries
-	if ac.MaxRetries >= 0 {
+	if ac.MaxRetries > 0 {
 		a.maxRetries = ac.MaxRetries
 	}
+
+	if ac.DisableRetries {
+		a.maxRetries = 0
+	}
+
 	a.minRetryDelay = minRetryWait
 	if ac.MinRetryDelay != "" {
 		mr, err := time.ParseDuration(ac.MinRetryDelay)
@@ -198,6 +204,7 @@ func New(ac *Config) (*API, error) {
 		}
 		a.minRetryDelay = mr
 	}
+
 	a.maxRetryDelay = maxRetryWait
 	if ac.MaxRetryDelay != "" {
 		mr, err := time.ParseDuration(ac.MaxRetryDelay)


### PR DESCRIPTION
* upd: Implements a new DisableRetries configuration setting to allow the retry functionality to be disabled when needed.